### PR TITLE
Implement a SimpleDBResourceTracker for usage in `view`

### DIFF
--- a/neckbeard/configuration.py
+++ b/neckbeard/configuration.py
@@ -67,7 +67,7 @@ def evaluate_configuration_templates(configuration, context, debug_trace=''):
     `context` is the template context which Jinja2 will use for evaluation.
 
     `debug_trace` is a dot-separated list to track how a key is nested for
-    template evaluation (eg. 'neckbeard_meta.resource_tracker.backend_path') so
+    template evaluation (eg. 'neckbeard_meta.resource_tracker.path') so
     that error messages about template problems can point users to the exact
     place in their `configuration` where the error occurred. The recursive
     calls build this up.

--- a/neckbeard/configuration.py
+++ b/neckbeard/configuration.py
@@ -531,4 +531,4 @@ class ConfigurationManager(object):
                 )
 
                 with open(resource_file, 'w') as fp:
-                    json.dump(resource_config, fp)
+                    json.dump(resource_config, fp, indent=4)

--- a/neckbeard/environment_manager.py
+++ b/neckbeard/environment_manager.py
@@ -4,7 +4,6 @@ from copy import copy
 from datetime import datetime
 
 from boto import ec2, rds
-from fabric.api import env, require
 
 from neckbeard.cloud_resource import InfrastructureNode
 
@@ -57,6 +56,14 @@ class WaitTimedOut(Exception):
     pass
 
 
+class MissingAWSCredentials(Exception):
+    pass
+
+
+class NonUniformAWSCredentials(Exception):
+    pass
+
+
 class Deployment(object):
     """
     Use configuration info to classify all currently running ec2 and RDS
@@ -66,26 +73,75 @@ class Deployment(object):
         """
         ``deployment_name`` A string uniquely identifying a deployment.
         """
-        require('aws_secret_access_key')
-        require('aws_access_key_id')
-
         self.deployment_name = deployment_name
         self.deployment_confs = {}
         self.deployment_confs['ec2'] = ec2_nodes
         self.deployment_confs['rds'] = rds_nodes
         self.deployment_confs['elb'] = elb_nodes
 
+        aws_credentials = self._get_valid_aws_credentials(
+            self.deployment_confs,
+        )
+
         self._pending_gen_id = None
         self._active_gen_id = None
 
         self.ec2conn = ec2.EC2Connection(
-            env.aws_access_key_id,
-            env.aws_secret_access_key,
+            aws_credentials['access_key_id'],
+            aws_credentials['secret_access_key'],
         )
         self.rdsconn = rds.RDSConnection(
-            env.aws_access_key_id,
-            env.aws_secret_access_key,
+            aws_credentials['access_key_id'],
+            aws_credentials['secret_access_key'],
         )
+
+    def _get_valid_aws_credentials(self, deployment_confs):
+        # TODO: Instead of just ensuring that all of the resources use the same
+        # credentials, actually manage multiple connection
+        aws_credentials = {
+            'access_key_id': None,
+            'secret_access_key': None,
+        }
+        for aws_type, configs_of_type in deployment_confs.items():
+            for name, resource_config in configs_of_type.items():
+                aws_config = resource_config.get('aws')
+                if aws_config is None:
+                    raise MissingAWSCredentials(
+                        "%s resource %s has no 'aws' configs" % (
+                            aws_type,
+                            name,
+                        ),
+                    )
+
+                # Ensure that the keys exist and that they're not different
+                # from those found on other resources
+                for key in ['access_key_id', 'secret_access_key']:
+                    value = aws_config.get(key)
+
+                    if value is None:
+                        raise MissingAWSCredentials(
+                            "%s resource %s has no '%s' config" % (
+                                aws_type,
+                                name,
+                                key,
+                            ),
+                        )
+                    other_resource_value = aws_credentials.get(key)
+                    if other_resource_value is not None:
+                        if value != other_resource_value:
+                            raise NonUniformAWSCredentials(
+                                (
+                                    "%s resource %s has no '%s' config "
+                                    "different from previously seen"
+                                ) % (
+                                    aws_type,
+                                    name,
+                                    key,
+                                ),
+                            )
+                    aws_credentials[key] = value
+
+        return aws_credentials
 
     @property
     def active_gen_id(self):

--- a/neckbeard/environment_manager.py
+++ b/neckbeard/environment_manager.py
@@ -246,6 +246,10 @@ class Deployment(object):
                     node.aws_type,
                     node.name,
                 )
+                logger.info(
+                    "Available configurations: %s",
+                    self.deployment_confs[node.aws_type].keys(),
+                )
             else:
                 node.set_deployment_info(
                     self.deployment_confs[node.aws_type][node.name])

--- a/neckbeard/output.py
+++ b/neckbeard/output.py
@@ -32,6 +32,7 @@ LOGGERS = [
     'cli',
     'configuration',
     'loader',
+    'environment_manager',
 ]
 
 

--- a/neckbeard/resource_tracker/__init__.py
+++ b/neckbeard/resource_tracker/__init__.py
@@ -15,13 +15,14 @@ def build_tracker_from_config(configuration_manager):
     neckbeard_config = configuration_manager.get_neckbeard_meta_config()
 
     tracker_config = neckbeard_config['resource_tracker']
-    backend_path = tracker_config['backend_path']
-    backend_config = tracker_config['backend']
+    tracker_path = tracker_config['path']
+    tracker_init = tracker_config['init']
 
-    if backend_path == 'neckbeard.resource_tracker.SimpleDBResourceTracker':
-        # This a horribly hacky way to load the backend. Instead, we should use
-        # a plugin registration system to instantiate these.
-        return SimpleDBResourceTracker(**backend_config)
+    if tracker_path == 'neckbeard.resource_tracker.SimpleDBResourceTracker':
+        # This a horribly hacky way to load the chosen ResourceTracker.
+        # Instead, we should use a plugin registration system to instantiate
+        # these.
+        return SimpleDBResourceTracker(**tracker_init)
     else:
         raise NotImplementedError()
 
@@ -32,6 +33,9 @@ class ResourceTrackerBase(object):
     resources. It's the only real "memory" that persists between runs outside
     of the cloud APIs themselves. It tracks nodes, their deployment state,
     their generation and their environment.
+
+    The `__init__` for a `ResourceTracker` will be passed as kwargs all of the
+    configuration from `neckbeard_meta.resource_tracker.init`.
     """
 
 

--- a/neckbeard/tests/bin/test_neckbeard.py
+++ b/neckbeard/tests/bin/test_neckbeard.py
@@ -2,6 +2,9 @@
 import unittest2
 from os import path
 
+import mock
+import boto.exception
+
 from neckbeard.bin.neckbeard import run_commands
 
 FIXTURE_CONFIGS_DIR = path.abspath(
@@ -21,5 +24,18 @@ class TestRunCommands(unittest2.TestCase):
         # Let's use the minimal configs
         configuration_dir = path.join(FIXTURE_CONFIGS_DIR, 'minimal')
 
-        return_code = run_commands('view', 'beta', configuration_dir)
-        self.assertEqual(return_code, 0)
+        with mock.patch(
+            'neckbeard.resource_tracker.simpledb.SimpleDB',
+            autospec=True,
+        ):
+            # Until we can either mock out boto with a version of moto that
+            # supports python 2.6 or we create a local/mockable
+            # ResourceTracker, we can only test that we try to authenticate
+            # with boto and then break. That counts as passing, for now.
+            self.assertRaises(
+                boto.exception.NoAuthHandlerFound,
+                run_commands,
+                'view',
+                'beta',
+                configuration_dir,
+            )

--- a/neckbeard/tests/fixture_configs/minimal/neckbeard_meta.yaml
+++ b/neckbeard/tests/fixture_configs/minimal/neckbeard_meta.yaml
@@ -1,7 +1,7 @@
 resource_tracker:
-  backend_path: "neckbeard.resource_tracker.SimpleDBResourceTracker"
-  backend:
+  path: "neckbeard.resource_tracker.SimpleDBResourceTracker"
+  init:
     domain: "neckbeard-resource-tracker"
-    aws_access_key_id: "{{ secrets.resource_tracker.backend.aws_access_key_id }}"
-    aws_secret_access_key: "{{ secrets.resource_tracker.backend.aws_secret_access_key }}"
+    aws_access_key_id: "{{ secrets.resource_tracker.init.aws_access_key_id }}"
+    aws_secret_access_key: "{{ secrets.resource_tracker.init.aws_secret_access_key }}"
 neckbeard_conf_version: '0.1'

--- a/neckbeard/tests/fixture_configs/minimal/secrets.json
+++ b/neckbeard/tests/fixture_configs/minimal/secrets.json
@@ -3,7 +3,7 @@
     "environments": {},
     "neckbeard_meta": {
         "resource_tracker": {
-            "backend": {
+            "init": {
                 "aws_access_key_id": null,
                 "aws_secret_access_key": null
             }

--- a/neckbeard/tests/fixture_configs/minimal/secrets.tpl.json
+++ b/neckbeard/tests/fixture_configs/minimal/secrets.tpl.json
@@ -3,7 +3,7 @@
     "environments": {},
     "neckbeard_meta": {
         "resource_tracker": {
-            "backend": {
+            "init": {
                 "aws_access_key_id": null,
                 "aws_secret_access_key": null
             }

--- a/neckbeard/tests/fixture_configs/minimal_yaml/neckbeard_meta.yaml
+++ b/neckbeard/tests/fixture_configs/minimal_yaml/neckbeard_meta.yaml
@@ -1,8 +1,8 @@
 resource_tracker:
-  backend_path: "neckbeard.resource_tracker.SimpleDBResourceTracker"
-  backend:
+  path: "neckbeard.resource_tracker.SimpleDBResourceTracker"
+  init:
     domain: "neckbeard-resource-tracker"
-    aws_access_key_id: "{{ secrets.resource_tracker.backend.aws_access_key_id }}"
-    aws_secret_access_key: "{{ secrets.resource_tracker.backend.aws_secret_access_key }}"
+    aws_access_key_id: "{{ secrets.resource_tracker.init.aws_access_key_id }}"
+    aws_secret_access_key: "{{ secrets.resource_tracker.init.aws_secret_access_key }}"
 neckbeard_conf_version: '0.1'
 

--- a/neckbeard/tests/fixture_configs/minimal_yaml/secrets.tpl.yaml
+++ b/neckbeard/tests/fixture_configs/minimal_yaml/secrets.tpl.yaml
@@ -1,7 +1,7 @@
 environments: {}
 neckbeard_meta:
     resource_tracker:
-        backend:
+        init:
             aws_access_key_id: null
             aws_secret_access_key: null
 neckbeard_conf_version: '0.1'

--- a/neckbeard/tests/fixture_configs/minimal_yaml/secrets.yaml
+++ b/neckbeard/tests/fixture_configs/minimal_yaml/secrets.yaml
@@ -1,7 +1,7 @@
 environments: {}
 neckbeard_meta:
     resource_tracker:
-        backend:
+        init:
             aws_access_key_id: null
             aws_secret_access_key: null
 neckbeard_conf_version: '0.1'

--- a/neckbeard/tests/test_configuration.py
+++ b/neckbeard/tests/test_configuration.py
@@ -1119,7 +1119,7 @@ class TestConfigExpansion(unittest2.TestCase):
             NeckbeardLoader.VERSION_OPTION: '0.1',
             'neckbeard_meta': {
                 'resource_tracker': {
-                    'backend': {
+                    'init': {
                         'foo': 'secret',
                     },
                 },
@@ -1129,17 +1129,17 @@ class TestConfigExpansion(unittest2.TestCase):
             NeckbeardLoader.VERSION_OPTION: '0.1',
             'neckbeard_meta': {
                 'resource_tracker': {
-                    'backend_path': "neckbeard.resource_tracker.ResourceTrackerBase",  # NOQA
+                    'path': "neckbeard.resource_tracker.ResourceTrackerBase",  # NOQA
                 },
             },
         }
         neckbeard_meta = {
             NeckbeardLoader.VERSION_OPTION: '0.1',
             'resource_tracker': {
-                'backend_path': "{{ constants.resource_tracker.backend_path }}",  # NOQA
-                'backend': {
+                'path': "{{ constants.resource_tracker.path }}",  # NOQA
+                'init': {
                     "hard_coded": "hard_coded",
-                    "secret": "{{ secrets.resource_tracker.backend.foo }}",
+                    "secret": "{{ secrets.resource_tracker.init.foo }}",
                 },
             },
         }
@@ -1154,8 +1154,8 @@ class TestConfigExpansion(unittest2.TestCase):
         expanded_configuration = configuration.get_neckbeard_meta_config()
         expected = {
             'resource_tracker': {
-                'backend_path': "neckbeard.resource_tracker.ResourceTrackerBase",  # NOQA
-                'backend': {
+                'path': "neckbeard.resource_tracker.ResourceTrackerBase",  # NOQA
+                'init': {
                     "hard_coded": "hard_coded",
                     "secret": "secret",
                 },

--- a/neckbeard/tests/test_environment_manager.py
+++ b/neckbeard/tests/test_environment_manager.py
@@ -1,0 +1,127 @@
+import mock
+import unittest2
+
+from neckbeard.environment_manager import (
+    Deployment,
+    MissingAWSCredentials,
+    NonUniformAWSCredentials,
+)
+
+
+class TestConfigValidation(unittest2.TestCase):
+    def test_differing_aws_credentials(self):
+        ec2_configs = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+                "aws": {
+                    "access_key_id": "FOO",
+                    "secret_access_key": "FOO",
+                },
+            },
+        }
+        rds_configs = {
+            'web1-0': {
+                "name": "web1",
+                "unique_id": "web1-0",
+                "aws": {
+                    "access_key_id": "BAR",
+                    "secret_access_key": "BAR",
+                },
+            },
+        }
+        self.assertRaises(
+            NonUniformAWSCredentials,
+            lambda: Deployment('test', ec2_configs, rds_configs, {}),
+        )
+
+    def test_aws_credentials_none(self):
+        none_configs = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+                "aws": {
+                    "access_key_id": None,
+                    "secret_access_key": None,
+                },
+            },
+        }
+        self.assertRaises(
+            MissingAWSCredentials,
+            lambda: Deployment('test', none_configs, {}, {}),
+        )
+
+    def test_no_aws_level(self):
+        missing_aws_configs = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+            },
+        }
+        self.assertRaises(
+            MissingAWSCredentials,
+            lambda: Deployment('test', missing_aws_configs, {}, {}),
+        )
+
+    def test_no_aws_access_key(self):
+        no_access_key = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+                "aws": {
+                    "secret_access_key": "FOO",
+                },
+            },
+        }
+        self.assertRaises(
+            MissingAWSCredentials,
+            lambda: Deployment('test', no_access_key, {}, {}),
+        )
+
+    def test_no_aws_secret_key(self):
+        no_secret_key = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+                "aws": {
+                    "access_key_id": "FOO",
+                },
+            },
+        }
+        self.assertRaises(
+            MissingAWSCredentials,
+            lambda: Deployment('test', no_secret_key, {}, {}),
+        )
+
+    def test_boto_connections_created(self):
+        # If the AWS credentials are valid, those credentials are used to
+        # create connections
+        ec2_configs = {
+            'web0-0': {
+                "name": "web0",
+                "unique_id": "web0-0",
+                "aws": {
+                    "access_key_id": "FOO",
+                    "secret_access_key": "FOO",
+                },
+            },
+        }
+        rds_configs = {
+            'web1-0': {
+                "name": "web1",
+                "unique_id": "web1-0",
+                "aws": {
+                    "access_key_id": "FOO",
+                    "secret_access_key": "FOO",
+                },
+            },
+        }
+
+        with mock.patch('boto.auth.get_auth_handler', autospec=True):
+            deployment = Deployment('test', ec2_configs, rds_configs, {})
+        self.assertNotEqual(deployment.ec2conn, None)
+        self.assertNotEqual(deployment.rdsconn, None)
+
+        for conn in [deployment.ec2conn, deployment.rdsconn]:
+            self.assertEqual(conn.access_key, 'FOO')
+            self.assertEqual(conn.secret_key, 'FOO')

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,3 +1,4 @@
 nose
 unittest2==0.5.1
 flake8==2.0
+mock==1.0.1


### PR DESCRIPTION
With the code imported from PolicyStat, the `neckbeard.cloud_resource:InfrastructureNode` object is configured as a [python-simpledb](https://github.com/winhamwr/python-simpledb?source=cr) object (using the winhamwr fork). This lets us use ORM-style access to the backend, which is pretty nice, but it might be too complex of an interface to implement for folks wanting to add other backends. The problem with extensibility is that the SimpleDB connection is configured via Meta parameters. I maybe figured out how to get around this by having `neckbeard.environment_manager:Deployment` is initialize the connection in the constructor there.

Instead of doing initialization in the constructor:
1. Use `neckbeard.resource_tracker:SimpleDBResourceTracker` to handle all of that. Figure out how that object and the environment manager should interface.
2. If doing 1 didn't require a ton of code, also see about finishing the implementation of `view` and throwing some tests on the ResourceTracker.
